### PR TITLE
Publish package to the crates.io registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "vkdocs-rs"
 version = "0.1.0"
 edition = "2021"
+description = "Supplementary VkDocs Rust library"
+license = "BSD-3-Clause"
+authors = ["Georgiy Belyanin <belyaningeorge@ya.ru>"]
+repository = "https://github.com/georgiy-belyanin/vkdocs-rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2025
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 VkDocs-rs is a supplementary crate for working with VK-Docs format ([see open-source VK Cloud documentation for more information](https://github.com/vk-cs/docs-public)). This crate helps to maintain [VkDocs meta files](https://github.com/vk-cs/docs-public/blob/master/guides/how-it-works.md) and update it correspondingly to the changes.
 
+## Installation
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+vkdocs = "0.1"
+```
+
 ## Example usage
 
 Here's a basic usage of the VkDocs-rs crate.


### PR DESCRIPTION
Now this package is available on crates.io. This is achieved through
two patches within this patchset.

* Add cargo license information and description.
* Add information on installation from crates.io.

See [vkdocs-rs](https://crates.io/crates/vkdocs-rs).
