### PR TITLE
Setup sections meta info automatically

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ impl Meta {
     }
 }
 
+#[derive(Default)]
 pub struct Vkdoc {
     path: PathBuf,
 }


### PR DESCRIPTION
This patchset fixes a few bugs and allows VKDoc to automatically
initialize the section meta information when creating an article.

- Ignore created/updated timestamps in meta.
- Allow Vkdoc project default value.
- Require article paths to be relative.
- Initialize sections meta automatically.
